### PR TITLE
cover_imgのNot Null制約を削除

### DIFF
--- a/db/migrate/20230724064721_create_songs.rb
+++ b/db/migrate/20230724064721_create_songs.rb
@@ -6,7 +6,7 @@ class CreateSongs < ActiveRecord::Migration[7.0]
       t.integer :duration_time, null: false
       t.text :memo
       t.integer :transposition, null: false, default: 0, limit: 1
-      t.string :cover_img, null: false, default: ''
+      t.string :cover_img
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_010924) do
     t.integer "duration_time", null: false
     t.text "memo"
     t.integer "transposition", limit: 1, default: 0, null: false
-    t.string "cover_img", default: "", null: false
+    t.string "cover_img"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name", "artist"], name: "index_songs_on_name_and_artist", unique: true


### PR DESCRIPTION
Issue: #97 

## 概要
Songのマイグレーションファイルのcover_imgカラムからnull: falseを削除して画像なしでも曲を登録できるようにしました（曲の登録機能は #30 のPRになります）。

## 画面キャプチャ
![スクリーンショット 2023-08-01 9 50 55](https://github.com/hikarook94/setlist-helper/assets/59002337/69033b68-261d-4e27-af8b-b50366468029)

### #30 のブランチ上で実行したアプリのキャプチャ
<img width="550" alt="スクリーンショット 2023-08-01 9 56 07" src="https://github.com/hikarook94/setlist-helper/assets/59002337/5c2f777d-552c-43a6-8783-d2705f61cd97">

