### PR TITLE
曲の編集機能を追加

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -31,6 +31,22 @@ class SongsController < ApplicationController
     end
   end
 
+  def edit
+    @song = Song.find(params[:id])
+  end
+
+  def update
+    @song = Song.find(params[:id])
+    processed_params = song_params
+    processed_params[:duration_time] = to_ms(processed_params.delete(:minutes), processed_params.delete(:seconds))
+
+    if @song.update(processed_params)
+      redirect_to @song
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def song_params

--- a/app/helpers/songs_helper.rb
+++ b/app/helpers/songs_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 module SongsHelper
-  def mitunes_seconds(milli_seconds)
-    seconds = milli_seconds / 1000
-    "#{seconds / 60} 分 #{seconds % 60} 秒"
+  def to_minutes(milli_seconds)
+    (milli_seconds / 1000) / 60
+  end
+
+  def to_remaining_seconds(milli_seconds)
+    (milli_seconds / 1000) % 60
   end
 end

--- a/app/helpers/songs_helper.rb
+++ b/app/helpers/songs_helper.rb
@@ -2,10 +2,10 @@
 
 module SongsHelper
   def to_minutes(milli_seconds)
-    (milli_seconds / 1000) / 60
+    (milli_seconds.to_i / 1000) / 60
   end
 
   def to_remaining_seconds(milli_seconds)
-    (milli_seconds / 1000) % 60
+    (milli_seconds.to_i / 1000) % 60
   end
 end

--- a/app/views/songs/_errors.html.erb
+++ b/app/views/songs/_errors.html.erb
@@ -1,0 +1,9 @@
+<% if song.errors.any? %>
+  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
+    <ul>
+      <% song.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/songs/_form.html.erb
+++ b/app/views/songs/_form.html.erb
@@ -19,10 +19,11 @@
     <%= form.label :transposition, 'キー' %>
     <%= form.number_field :transposition, in: -7..7, step: 1 %>
   </div>
+  <div>
     <%= form.label :memo, 'メモ' %>
     <div>
       <%= form.text_area :memo %>
     </div>
-  <div></div>
+  </div>
   <%= form.submit '登録する' %>
 <% end %>

--- a/app/views/songs/_form.html.erb
+++ b/app/views/songs/_form.html.erb
@@ -1,0 +1,28 @@
+
+<%= form_with model: song do |form| %>
+  <div>
+    <%= form.file_field :cover_img %>
+  </div>
+  <div>
+    <%= form.text_field :name, placeholder:'曲名' %>
+  </div>
+  <div>
+    <%= form.text_field :artist, placeholder:'アーティスト名' %>
+  </div>
+  <div>
+    <%= form.text_field :minutes, value: to_minutes(song.duration_time) %>
+    <%= form.label :minutes, '分' %>
+    <%= form.text_field :seconds, value: to_remaining_seconds(song.duration_time) %>
+    <%= form.label :seconds, '秒' %>
+  </div>
+  <div>
+    <%= form.label :transposition, 'キー' %>
+    <%= form.number_field :transposition, in: -7..7, step: 1 %>
+  </div>
+    <%= form.label :memo, 'メモ' %>
+    <div>
+      <%= form.text_area :memo %>
+    </div>
+  <div></div>
+  <%= form.submit '登録する' %>
+<% end %>

--- a/app/views/songs/edit.html.erb
+++ b/app/views/songs/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'form', locals: { song: @song } %>

--- a/app/views/songs/edit.html.erb
+++ b/app/views/songs/edit.html.erb
@@ -1,1 +1,3 @@
+<%= render partial: 'errors', locals: { song: @song } %>
+
 <%= render partial: 'form', locals: { song: @song } %>

--- a/app/views/songs/new.html.erb
+++ b/app/views/songs/new.html.erb
@@ -8,30 +8,4 @@
   </div>
 <% end %>
 
-<%= form_with model: @song do |form| %>
-  <div>
-    <%= form.file_field :cover_img %>
-  </div>
-  <div>
-    <%= form.text_field :name, placeholder:'曲名' %>
-  </div>
-  <div>
-    <%= form.text_field :artist, placeholder:'アーティスト名' %>
-  </div>
-  <div>
-    <%= form.text_field :minutes %>
-    <%= form.label :minutes, '分' %>
-    <%= form.text_field :seconds %>
-    <%= form.label :seconds, '秒' %>
-  </div>
-  <div>
-    <%= form.label :transposition, 'キー' %>
-    <%= form.number_field :transposition, in: -7..7, step: 1 %>
-  </div>
-    <%= form.label :memo, 'メモ' %>
-    <div>
-      <%= form.text_area :memo %>
-    </div>
-  <div></div>
-  <%= form.submit '登録する' %>
-<% end %>
+<%= render partial: 'form', locals: { song: @song } %>

--- a/app/views/songs/new.html.erb
+++ b/app/views/songs/new.html.erb
@@ -1,11 +1,3 @@
-<% if @song.errors.any? %>
-  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
-    <ul>
-      <% @song.errors.each do |error| %>
-        <li><%= error.full_message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render partial: 'errors', locals: { song: @song } %>
 
 <%= render partial: 'form', locals: { song: @song } %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -5,5 +5,8 @@
 <p><%= @song.artist %></p>
 <p><%= to_minutes(@song.duration_time) %>分<%= to_remaining_seconds(@song.duration_time) %>秒</p>
 <p><%= @song.transposition %></p>
+<div>
+  <%= @song.memo %>
+</div>
 <%= link_to '編集', edit_song_path %>
 <%= link_to '戻る', songs_path %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -5,4 +5,5 @@
 <p><%= @song.artist %></p>
 <p><%= to_minutes(@song.duration_time) %>分<%= to_remaining_seconds(@song.duration_time) %>秒</p>
 <p><%= @song.transposition %></p>
+<%= link_to '編集', edit_song_path %>
 <%= link_to '戻る', songs_path %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -3,6 +3,6 @@
 <% end %>
 <h1><%= @song.name %></h1>
 <p><%= @song.artist %></p>
-<p><%= mitunes_seconds(@song.duration_time) %></p>
+<p><%= to_minutes(@song.duration_time) %>分<%= to_remaining_seconds(@song.duration_time) %>秒</p>
 <p><%= @song.transposition %></p>
 <%= link_to '戻る', songs_path %>


### PR DESCRIPTION
Issue: #79

## 概要
- 曲詳細ページに編集ボタンを追加してedit画面へ遷移する
- edit画面で編集可能な項目
  1. 曲名
  2. アーティスト名
  3. 分秒
  4. キー
  5. メモ
- 新規作成画面とフォーム、エラー表示の共通化

## 画面キャプチャ
### 編集画面
<img width="800" alt="スクリーンショット 2023-08-02 10 19 31" src="https://github.com/hikarook94/setlist-helper/assets/59002337/afc09cec-1b19-4cb6-a38a-6f0296a14b57">

### エラー表示
<img width="800" alt="スクリーンショット 2023-08-02 10 19 58" src="https://github.com/hikarook94/setlist-helper/assets/59002337/e96c2f53-2a5a-4a4a-ba05-934184c2eaef">
 