### PR TITLE
曲を削除する機能の追加

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -47,6 +47,12 @@ class SongsController < ApplicationController
     end
   end
 
+  def destroy
+    song = Song.find(params[:id])
+    song.destroy!
+    redirect_to songs_path(filter_by: @artist)
+  end
+
   private
 
   def song_params

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -49,9 +49,8 @@ class SongsController < ApplicationController
 
   def destroy
     song = Song.find(params[:id])
-    song.destroy!
-    redirect_to songs_path(query_params(url))
-      redirect_to songs_path(query_params(URI(request.referer)))
+    flash[:alert] = '削除に失敗しました。' unless song.destroy
+    redirect_to songs_path(query_params(URI(request.referer)))
   end
 
   private

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -48,10 +48,10 @@ class SongsController < ApplicationController
   end
 
   def destroy
-    url = URI(request.referer)
     song = Song.find(params[:id])
     song.destroy!
     redirect_to songs_path(query_params(url))
+      redirect_to songs_path(query_params(URI(request.referer)))
   end
 
   private

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -48,9 +48,10 @@ class SongsController < ApplicationController
   end
 
   def destroy
+    url = URI(request.referer)
     song = Song.find(params[:id])
     song.destroy!
-    redirect_to songs_path(filter_by: @artist)
+    redirect_to songs_path(query_params(url))
   end
 
   private
@@ -62,5 +63,12 @@ class SongsController < ApplicationController
   def to_ms(minutes, seconds)
     total_seconds = seconds.to_i + minutes.to_i * 60
     total_seconds * 1000
+  end
+
+  def query_params(url)
+    return {} if url.query == nil
+
+    query_hash = CGI.parse(url.query)
+    query_hash.transform_values {|value| value.first}
   end
 end

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -66,9 +66,9 @@ class SongsController < ApplicationController
   end
 
   def query_params(url)
-    return {} if url.query == nil
+    return {} if url.query.nil?
 
     query_hash = CGI.parse(url.query)
-    query_hash.transform_values {|value| value.first}
+    query_hash.transform_values(&:first)
   end
 end

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -16,10 +16,14 @@
   <% end %>
 <% else %>
   <% @songs.each do |song| %>
-    <div>
-      <p><%= link_to song.name, song %></p>
-      <p><%= song.artist %><p>
-      <p><%= link_to '削除', song, data: { turbo_method: :delete } %></p>
+    <div class="mb-3 p-2 flex">
+      <div class="mr-4">
+        <p><%= link_to song.name, song %></p>
+        <p><%= song.artist %><p>
+      </div>
+      <div>
+        <p><%= link_to '削除', song, data: { turbo_method: :delete } %></p>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -19,6 +19,7 @@
     <div>
       <p><%= link_to song.name, song %></p>
       <p><%= song.artist %><p>
+      <p><%= link_to '削除', song, data: { turbo_method: :delete } %></p>
     </div>
   <% end %>
 <% end %>

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -8,6 +8,13 @@
     <%= select :option, :filter, options_for_select([['曲', songs_path(sort_by: 'songs')], ['アーティスト', songs_path(sort_by: 'artists')]], songs_path({sort_by: @sort_by})), {}, {onchange:"Turbo.visit(value)"} %>
   <% end %>
 </div>
+
+<% flash.each do |_, message| %>
+  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
+    <%= message %>
+  </div>
+<% end %>
+
 <% if @sort_by == 'artists' %>
     <% @artists.each do |artist| %>
     <div>


### PR DESCRIPTION
#35 
## 概要
- 曲一覧ページの各曲に削除ボタンを追加しました
- 削除機能を追加しました
- 削除後のリダイレクト先にリクエスト元のクエリ文字列を指定できるようにしました

## 画面キャプチャ
<img width="800" alt="スクリーンショット 2023-08-02 14 05 23" src="https://github.com/hikarook94/setlist-helper/assets/59002337/72476962-5819-4adc-b751-06b8f2b2e334">
