### PR TITLE
フッターを追加

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,17 @@
+glob: "**/*.{html,text,js}{+*,}.erb"
+exclude:
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
+linters:
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Layout/InitialIndentation:
+        Enabled: false
+  # generatorが自動生成したerbがこの規則に従っていないことが多いので、検証対象から外す
+  SelfClosingTag:
+    enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,6 +12,8 @@ linters:
         Enabled: false
       Layout/InitialIndentation:
         Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
   # generatorが自動生成したerbがこの規則に従っていないことが多いので、検証対象から外す
   SelfClosingTag:
     enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -14,6 +14,8 @@ linters:
         Enabled: false
       Layout/TrailingEmptyLines:
         Enabled: false
+      Layout/FirstArgumentIndentation:
+        Enabled: false
   # generatorが自動生成したerbがこの規則に従っていないことが多いので、検証対象から外す
   SelfClosingTag:
     enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development do
   # gem "spring"
 
   gem 'bullet'
+  gem 'erb_lint', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,13 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -102,6 +109,13 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    erb_lint (0.5.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.12.0)
     ffi (1.15.5)
     globalid (1.1.0)
@@ -247,6 +261,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -294,6 +309,7 @@ DEPENDENCIES
   carrierwave (~> 3.0)
   cssbundling-rails
   debug
+  erb_lint
   jbuilder
   jsbundling-rails
   mysql2 (~> 0.5)

--- a/app/javascript/components/ListedSongEdit.js
+++ b/app/javascript/components/ListedSongEdit.js
@@ -16,7 +16,10 @@ function ListedSongEdit({ song, onSongDeleted }) {
           </div>
         </li>
       </div>
-      <div className="text-gray-400 absolute top-0 right-2" onClick={handleDelete}>
+      <div
+        className="text-gray-400 absolute top-0 right-2"
+        onClick={handleDelete}
+      >
         ×
       </div>
     </div>

--- a/app/javascript/components/Setlist.js
+++ b/app/javascript/components/Setlist.js
@@ -29,7 +29,7 @@ const Setlist = () => {
 
   return (
     <>
-      <div className="h-screen p-4">
+      <div className="h-4/5 p-4">
         <div className="flex relative justify-center items-center mb-2 mx-4">
           <Link to="/setlists">
             <div className="w-16 absolute vertical-center top-6 left-1">＜</div>

--- a/app/javascript/components/Setlist.js
+++ b/app/javascript/components/Setlist.js
@@ -29,7 +29,7 @@ const Setlist = () => {
 
   return (
     <>
-      <div className="h-4/5 p-4">
+      <div className="p-4">
         <div className="flex relative justify-center items-center mb-2 mx-4">
           <Link to="/setlists">
             <div className="w-16 absolute vertical-center top-6 left-1">＜</div>
@@ -47,7 +47,7 @@ const Setlist = () => {
           <span>/</span>
           <span>{convertToHours(setlist.target_duration_time)}</span>
         </div>
-        <div className="relative h-4/5 overflow-y-auto mx-2 mb-8">
+        <div className="relative max-h-[600px] overflow-y-auto mx-2 mb-8">
           <div className="h-full">
             <ul>
               {setlist.songs.map((song, index) => (

--- a/app/javascript/components/SetlistSongEdit.js
+++ b/app/javascript/components/SetlistSongEdit.js
@@ -163,7 +163,9 @@ const SetlistSongEdit = () => {
     <div className="relative">
       <div className="h-8">
         <Link to="/setlists">
-              <div className="absolute vertical-center top-0 right-0 text-gray-400">×</div>
+          <div className="absolute vertical-center top-0 right-0 text-gray-400">
+            ×
+          </div>
         </Link>
       </div>
       <form onSubmit={handleSubmit(onSubmit)} className="mx-4">

--- a/app/javascript/components/Setlists.js
+++ b/app/javascript/components/Setlists.js
@@ -21,7 +21,7 @@ const Setlists = () => {
   }, []);
 
   return (
-    <div className="h-screen">
+    <div className="">
       <h1 className="text-2xl text-center mb-4 pt-4">セットリスト</h1>
       <div className="p-4">
         <div className="mb-1 px-4 py-2 border">

--- a/app/javascript/image_upload.js
+++ b/app/javascript/image_upload.js
@@ -1,14 +1,18 @@
-window.addEventListener('load', () => {
+document.addEventListener("turbo:load", () => {
   const uploader = document.querySelector('#uploader');
-  if (uploader) {
-    uploader.addEventListener('change', (e) => {
-      const file = uploader.files[0];
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onload = () => {
-        const image = reader.result;
-        document.querySelector('#cover_image_preview').setAttribute('src', image);
+  if (!uploader) return;
+
+  uploader.addEventListener('change', event => {
+    const file = event.target.files[0];
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const preview = document.querySelector('#preview');
+      if (preview) {
+        preview.innerHTML = `<img src="${reader.result}">`;
       }
-    });
-  }
+    };
+
+    reader.readAsDataURL(file);
+  });
 });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,16 +15,7 @@
       <%= yield %>
     </main>
 
-    <footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
-      <nav class="align-center flex w-full h-full">
-        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/songs') %>">
-          <%= link_to 'レパートリー', songs_path, class: '' %>
-        </div>
-        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/setlists') %>">
-          <%= link_to 'セットリスト', setlists_path, data: { turbo: false }, class: '' %>
-        </div>
-      </nav>
-    </footer>
+    <%= render partial: 'partials/footer' %>
 
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,14 +15,12 @@
       <%= yield %>
     </main>
 
-    <% if request.path.start_with?('/songs') || request.path == '/setlists' %>
-      <footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
-        <nav class="align-center flex w-full h-full">
-          <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(songs_path) %>"><%= link_to 'レパートリー', songs_path, class: "" %></div>
-          <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(setlists_path) %>"><%= link_to 'セットリスト', setlists_path, class: "" %></div>
-        </nav>
-      </footer>
-    <% end %>
+    <footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
+      <nav class="align-center flex w-full h-full">
+        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(songs_path) %>"><%= link_to 'レパートリー', songs_path, class: "" %></div>
+        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(setlists_path) %>"><%= link_to 'セットリスト', setlists_path, data:{turbo: false}, class: "" %></div>
+      </nav>
+    </footer>
 
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,8 @@
 
     <footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
       <nav class="align-center flex w-full h-full">
-        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(songs_path) %>"><%= link_to 'レパートリー', songs_path, class: "" %></div>
-        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(setlists_path) %>"><%= link_to 'セットリスト', setlists_path, data:{turbo: false}, class: "" %></div>
+        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/songs') %>"><%= link_to 'レパートリー', songs_path, class: "" %></div>
+        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if  request.fullpath.start_with?('/setlists') %>"><%= link_to 'セットリスト', setlists_path, data:{turbo: false}, class: "" %></div>
       </nav>
     </footer>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,18 @@
   </head>
 
   <body>
-    <%= yield %>
+    <main class="">
+      <%= yield %>
+    </main>
+
+    <% if request.path.start_with?('/songs') || request.path == '/setlists' %>
+      <footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
+        <nav class="align-center flex w-full h-full">
+          <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(songs_path) %>"><%= link_to 'レパートリー', songs_path, class: "" %></div>
+          <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if current_page?(setlists_path) %>"><%= link_to 'セットリスト', setlists_path, class: "" %></div>
+        </nav>
+      </footer>
+    <% end %>
+
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= stylesheet_link_tag 'application', "data-turbo-track": 'reload' %>
+    <%= javascript_include_tag 'application', "data-turbo-track": 'reload', defer: true %>
   </head>
 
   <body>
@@ -17,8 +17,12 @@
 
     <footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
       <nav class="align-center flex w-full h-full">
-        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/songs') %>"><%= link_to 'レパートリー', songs_path, class: "" %></div>
-        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if  request.fullpath.start_with?('/setlists') %>"><%= link_to 'セットリスト', setlists_path, data:{turbo: false}, class: "" %></div>
+        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/songs') %>">
+          <%= link_to 'レパートリー', songs_path, class: '' %>
+        </div>
+        <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/setlists') %>">
+          <%= link_to 'セットリスト', setlists_path, data: { turbo: false }, class: '' %>
+        </div>
       </nav>
     </footer>
 

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -1,0 +1,10 @@
+<footer class="h-16 p-1 fixed w-full bottom-0 bg-white border">
+  <nav class="align-center flex w-full h-full">
+    <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/songs') %>">
+      <%= link_to 'レパートリー', songs_path, class: '' %>
+    </div>
+    <div class="pt-4 h-full w-1/2 text-center <%= 'bg-blue-300' if request.fullpath.start_with?('/setlists') %>">
+      <%= link_to 'セットリスト', setlists_path, data: { turbo: false }, class: '' %>
+    </div>
+  </nav>
+</footer>

--- a/app/views/songs/_form.html.erb
+++ b/app/views/songs/_form.html.erb
@@ -2,16 +2,14 @@
   <div class="h-64 mb-6">
     <div class="relative">
       <div class="border h-64 w-64 -ml-32 absolute top-1/2 left-1/2">
-        <label class="">
-          <div class="w-full h-full text-center" id="cover_image">
-            <% if @song.cover_img? %>
-              <%= image_tag @song.cover_img.url, size: "300x300" %>
-            <% else%>
-              <img id="cover_image_preview" src="">
-            <% end %>
-          </div>
-          <%= form.file_field :cover_img, class: "hidden", id: "uploader" %>
-        </label>
+          <% if @song.cover_img? %>
+            <%= image_tag @song.cover_img.url, size: "300x300" %>
+          <% else%>
+            <label id="uploader_label" class="flex justify-center items-center h-full">
+              <div id="preview" class="text-center text-gray-400">画像を選択する</div>
+              <%= form.file_field :cover_img, class: "hidden", id: "uploader" %>
+            </label>
+          <% end %>
       </div>
     </div>
   </div>

--- a/app/views/songs/_form.html.erb
+++ b/app/views/songs/_form.html.erb
@@ -3,43 +3,43 @@
     <div class="relative">
       <div class="border h-64 w-64 -ml-32 absolute top-1/2 left-1/2">
           <% if @song.cover_img? %>
-            <%= image_tag @song.cover_img.url, size: "300x300" %>
-          <% else%>
+            <%= image_tag @song.cover_img.url, size: '300x300' %>
+          <% else %>
             <label id="uploader_label" class="flex justify-center items-center h-full">
               <div id="preview" class="text-center text-gray-400">画像を選択する</div>
-              <%= form.file_field :cover_img, class: "hidden", id: "uploader" %>
+              <%= form.file_field :cover_img, class: 'hidden', id: 'uploader' %>
             </label>
           <% end %>
       </div>
     </div>
   </div>
   <div class="px-4 mb-2">
-    <%= form.text_field :name, placeholder:'曲名', class: "border w-full px-4 py-2" %>
+    <%= form.text_field :name, placeholder: '曲名', class: 'border w-full px-4 py-2' %>
   </div>
   <div class="px-4 mb-2">
-    <%= form.text_field :artist, placeholder:'アーティスト名', class: "border w-full px-4 py-2" %>
+    <%= form.text_field :artist, placeholder: 'アーティスト名', class: 'border w-full px-4 py-2' %>
   </div>
   <div class="text-center mb-4">
     <span>
-      <%= form.text_field :minutes, value: to_minutes(song.duration_time), class: "border w-24 px-2 py-1 text-right" %>
-      <%= form.label :minutes, '分', class: "mr-2" %>
-      <%= form.text_field :seconds, value: to_remaining_seconds(song.duration_time), class: "border w-24 px-2 py-1 text-right" %>
-      <%= form.label :seconds, '秒', class: "" %>
+      <%= form.text_field :minutes, value: to_minutes(song.duration_time), class: 'border w-24 px-2 py-1 text-right' %>
+      <%= form.label :minutes, '分', class: 'mr-2' %>
+      <%= form.text_field :seconds, value: to_remaining_seconds(song.duration_time), class: 'border w-24 px-2 py-1 text-right' %>
+      <%= form.label :seconds, '秒', class: '' %>
     </span>
   </div>
   <div class="px-4 w-full mb-4">
-    <%= form.label :transposition, 'キー', class: "" %>
-    <%= form.number_field :transposition, in: -7..7, step: 1, class: "border text-right w-24 px-2 py-1 float-right" %>
+    <%= form.label :transposition, 'キー', class: '' %>
+    <%= form.number_field :transposition, in: -7..7, step: 1, class: 'border text-right w-24 px-2 py-1 float-right' %>
   </div>
   <div class="px-4 w-full mb-6">
     <div class="mb-2">
-      <%= form.label :memo, 'メモ', class: "" %>
+      <%= form.label :memo, 'メモ', class: '' %>
     </div>
     <div>
-      <%= form.text_area :memo, class: "border w-full h-32 px-2 py-2" %>
+      <%= form.text_area :memo, class: 'border w-full h-32 px-2 py-2' %>
     </div>
   </div>
   <div class="text-center">
-    <%= form.submit '登録する', class: "mx-0 rounded-full bg-blue-500 w-[80%] h-12" %>
+    <%= form.submit '登録する', class: 'mx-0 rounded-full bg-blue-500 w-[80%] h-12' %>
   </div>
 <% end %>

--- a/app/views/songs/edit.html.erb
+++ b/app/views/songs/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="h-full p-6">
   <div>
-    <%= link_to '＜', @song, class: "text-gray-400" %>
+    <%= link_to '＜', @song, class: 'text-gray-400' %>
   </div>
   <%= render partial: 'errors', locals: { song: @song } %>
 

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -11,7 +11,23 @@
         <%= link_to '＜', songs_path(sort_by: 'artists') %>
         <%= @artist %>
       <% else %>
-        <%= select :option, :filter, options_for_select([['曲', songs_path(sort_by: 'songs')], ['アーティスト', songs_path(sort_by: 'artists')]], songs_path({sort_by: @sort_by})), {}, {onchange:"Turbo.visit(value)", class:"bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"} %>
+        <%= select(
+          :option,
+          :filter,
+          options_for_select(
+            [
+              ['曲', songs_path(sort_by: 'songs')],
+              ['アーティスト', songs_path(sort_by: 'artists')]
+            ],
+            songs_path({ sort_by: @sort_by })
+          ),
+          {},
+          {
+            onchange: 'Turbo.visit(value)',
+            class: 'bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5'
+          }
+        ) %>
+
       <% end %>
     </div>
 
@@ -26,7 +42,7 @@
           <% @artists.each do |artist| %>
             <div class="mb-1 px-2">
               <div class="px-4 py-2 border relative w-full h-12">
-                <%= link_to artist, songs_path(filter_by: artist), class:"absolute inset-0 flex items-center left-4" %>
+                <%= link_to artist, songs_path(filter_by: artist), class: 'absolute inset-0 flex items-center left-4' %>
               </div>
             </div>
           <% end %>

--- a/app/views/songs/new.html.erb
+++ b/app/views/songs/new.html.erb
@@ -1,6 +1,6 @@
 <div class="h-full p-6">
   <div>
-    <%= link_to '＜', songs_path, class: "text-gray-400" %>
+    <%= link_to '＜', songs_path, class: 'text-gray-400' %>
   </div>
 
   <%= render partial: 'errors', locals: { song: @song } %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -1,12 +1,12 @@
 <div class="h-screen p-4">
   <div>
-    <%= link_to '＜', songs_path, class: "text-gray-400" %>
+    <%= link_to '＜', songs_path, class: 'text-gray-400' %>
   </div>
   <div class="h-64 mb-6">
     <div class="relative">
       <div class="border h-64 w-64 -ml-32 absolute top-1/2 left-1/2">
         <% if @song.cover_img? %>
-          <%= image_tag @song.cover_img.url, size: "300x300" %>
+          <%= image_tag @song.cover_img.url, size: '300x300' %>
         <% end %>
       </div>
     </div>
@@ -38,7 +38,7 @@
   <div class="px-4 w-full mb-6">
     <p class="mb-2">メモ</p>
     <div class="border w-full h-32 px-2 py-2">
-      <%= @song.memo%>
+      <%= @song.memo %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- 全ページにわたって表示されるフッターを追加しました。
  - レパートリー・セットリストページへのリンクを追加しました。
  - URLによってセットリストorレパートリーの背景に色をつけ、ユーザーがどのページを見ているのかわかるようにしました。
- 画像アップロードの際にプレビューが表示されていなかった問題を修正しました。


## 画面キャプチャ
### フッター
<img width="367" alt="スクリーンショット 2023-08-29 9 33 53" src="https://github.com/hikarook94/setlist-helper/assets/59002337/afc0ca8b-4c49-412b-854c-b32d30c5e33c">

<img width="367" alt="スクリーンショット 2023-08-29 9 34 21" src="https://github.com/hikarook94/setlist-helper/assets/59002337/ef119508-5556-4a23-91f6-86599e2063eb">

### 画像アップロード
<img width="367" alt="スクリーンショット 2023-08-29 9 41 52" src="https://github.com/hikarook94/setlist-helper/assets/59002337/4f821aa2-9c8c-42f2-ab5b-a2f0a0079f47">

<img width="367" alt="スクリーンショット 2023-08-29 9 42 00" src="https://github.com/hikarook94/setlist-helper/assets/59002337/0fb2b8db-6d76-4eea-8a20-8311eff68ab2">
